### PR TITLE
moving non input format type extension files with optional argument (…

### DIFF
--- a/mailbag/__init__.py
+++ b/mailbag/__init__.py
@@ -139,7 +139,10 @@ mailbagit_options.add_argument(
     "-c", "--compress", help="Compress the mailbag as ZIP, TAR, or TAR.GZ", nargs=None, choices=["tar", "zip", "tar.gz"]
 )
 mailbagit_options.add_argument(
-    "-r", "--dry_run", help="A dry run performs a trial run with no changes made", default=False, action="store_true"
+    "-r", "--dry_run", help="A dry run performs a trial run with no changes made", default=False, action="store_true",
+)
+mailbagit_options.add_argument(
+    "-cf", "--companion_files", help="Companion files", default=False, action="store_true",
 )
 # Yet-to-be-implemented:
 """

--- a/mailbag/controller.py
+++ b/mailbag/controller.py
@@ -97,6 +97,12 @@ class Controller:
         attachments_dir = os.path.join(str(mailbag_dir), "data", "attachments")
         error_dir = os.path.join(parent_dir, str(self.args.mailbag_name) + "_errors")
 
+        #Getting a list of all the files
+        file_list=[]
+        for root, dirs, files in os.walk(parent_dir):
+            for file in files:
+                file_list.append(file)
+
         log.debug("Creating mailbag at " + str(mailbag_dir))
         if not self.args.dry_run:
             os.mkdir(mailbag_dir)
@@ -214,6 +220,19 @@ class Controller:
                 writer = csv.writer(f)
                 writer.writerows(error_csv)
 
+        #moving companion files
+        if self.args.companion_files:
+            new_path = os.path.join(mailbag_dir, "data", self.args.input)
+            new_files=[]
+            for root, dirs, files in os.walk(parent_dir):
+                for file in files:
+                    new_files.append(file)
+            for file in new_files:
+                if file in file_list and self.args.input not in file:
+                    old_path = os.path.join(parent_dir, file)
+                    shutil.move(old_path, new_path)
+
+
         if not self.args.dry_run:
             bag_size = 0
             for root, dirs, files in os.walk(os.path.join(str(mailbag_dir), "data")):
@@ -225,6 +244,7 @@ class Controller:
             bag.info["Bagging-Timestamp"] = now.strftime("%Y-%m-%dT%H:%M:%S")
             bag.info["Bagging-Date"] = now.strftime("%Y-%m-%d")
             bag.save(manifests=True)
+
 
         if self.args.compress and not self.args.dry_run:
             log.info("Compressing Mailbag")


### PR DESCRIPTION
…-cf)

 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.
Moves non input format files present in parent directory if provided with optional argument (-cf)
...

## Link to issue?
#136 
...

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [ ] All tests pass

#### How has this been tested?
**Operating System:** …
**Python Version:** …

## Licensing
- [ ] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
