### PR TITLE
Pst encoding

### DIFF
--- a/mailbagit/derivatives/eml.py
+++ b/mailbagit/derivatives/eml.py
@@ -122,7 +122,7 @@ class EmlDerivative(Derivative):
                                 if mimeType is None:
                                     mimeType = "text/plain"
                                     desc = "Mime type not found for attachment, set as " + mimeType
-                                    errors = common.handle_error(errors, None, desc, "warn")
+                                    errors = common.handle_error(errors, None, desc, "error")
                                 mimeType = mimeType.split("/")
                                 part = MIMEBase(mimeType[0], mimeType[1])
                                 part.set_payload(attachment.File)

--- a/mailbagit/formats/pst.py
+++ b/mailbagit/formats/pst.py
@@ -109,8 +109,6 @@ if not skip_registry:
                                 )
 
                         except Exception as e:
-                            print(encodings)
-                            # messageObj.plain_text_body.decode("windows=1252")
                             desc = "Error parsing message body"
                             errors = common.handle_error(errors, e, desc)
 

--- a/mailbagit/formats/pst.py
+++ b/mailbagit/formats/pst.py
@@ -98,9 +98,15 @@ if not skip_registry:
                                             encodings[2] = {"name": CODE_PAGES[value], "label": "PidTagMessageCodepage"}
 
                             if messageObj.html_body:
-                                html_body, html_encoding, errors = format.safely_decode(messageObj.html_body, encodings, errors)
+                                html_body, html_encoding, errors = format.safely_decode("HTML", messageObj.html_body, encodings, errors)
                             if messageObj.plain_text_body:
-                                text_body, text_encoding, errors = format.safely_decode(messageObj.plain_text_body, encodings, errors)
+                                encodings[len(encodings.keys()) + 1] = {
+                                    "name": chardet.detect(messageObj.plain_text_body)["encoding"],
+                                    "label": "detected",
+                                }
+                                text_body, text_encoding, errors = format.safely_decode(
+                                    "plain text", messageObj.plain_text_body, encodings, errors
+                                )
 
                         except Exception as e:
                             print(encodings)

--- a/mailbagit/formats/pst.py
+++ b/mailbagit/formats/pst.py
@@ -9,6 +9,7 @@ from mailbagit.email_account import EmailAccount
 from mailbagit.models import Email, Attachment
 import mailbagit.helper.format as format
 import mailbagit.helper.common as common
+from collections import OrderedDict
 
 # only create format if pypff is successfully importable -
 # pst is not supported otherwise
@@ -89,32 +90,21 @@ if not skip_registry:
                                         if entry.data:
                                             value = entry.get_data_as_integer()
                                             # Use the extract_msg code page in constants.py
-                                            encodings["PidTagInternetCodepage"] = CODE_PAGES[value]
+                                            encodings[1] = {"name": CODE_PAGES[value], "label": "PidTagInternetCodepage"}
                                     if entry.entry_type == LIBPFF_ENTRY_TYPE_MESSAGE_CODEPAGE:
                                         if entry.data:
                                             value = entry.get_data_as_integer()
                                             # Use the extract_msg code page in constants.py
-                                            encodings["PidTagMessageCodepage"] = CODE_PAGES[value]
+                                            encodings[2] = {"name": CODE_PAGES[value], "label": "PidTagMessageCodepage"}
 
                             if messageObj.html_body:
-                                if encodings["PidTagInternetCodepage"]:
-                                    html_encoding = encodings["PidTagInternetCodepage"]
-                                elif encodings["PidTagMessageCodepage"]:
-                                    html_encoding = encodings["PidTagMessageCodepage"]
-                                else:
-                                    html_encoding = chardet.detect(messageObj.html_body)["encoding"]
-                                html_body = messageObj.html_body.decode(html_encoding)
+                                html_body, html_encoding, errors = format.safely_decode(messageObj.html_body, encodings, errors)
                             if messageObj.plain_text_body:
-                                if encodings["PidTagInternetCodepage"]:
-                                    text_encoding = encodings["PidTagInternetCodepage"]
-                                elif encodings["PidTagMessageCodepage"]:
-                                    text_encoding = encodings["PidTagMessageCodepage"]
-                                else:
-                                    text_encoding = chardet.detect(messageObj.plain_text_body)["encoding"]
-                                text_encoding = chardet.detect(messageObj.plain_text_body)["encoding"]
-                                text_body = messageObj.plain_text_body.decode(text_encoding)
+                                text_body, text_encoding, errors = format.safely_decode(messageObj.plain_text_body, encodings, errors)
 
                         except Exception as e:
+                            print(encodings)
+                            # messageObj.plain_text_body.decode("windows=1252")
                             desc = "Error parsing message body"
                             errors = common.handle_error(errors, e, desc)
 

--- a/mailbagit/helper/format.py
+++ b/mailbagit/helper/format.py
@@ -35,7 +35,7 @@ def relativePath(mainPath, file):
         return relPath
 
 
-def safely_decode(binary_text, encodings, errors):
+def safely_decode(body_type, binary_text, encodings, errors):
     """
     Tries to safely decode text for message bodies using an encodings dict.
     Goes through encodings by priority and uses the first successful one.
@@ -43,6 +43,7 @@ def safely_decode(binary_text, encodings, errors):
     Fully documents the encoding and label for each one that fails
 
     Parameters:
+        body_type (str): a description of the body (i.e. HTML or Text)
         binary_text (binary): an encoded string
         encodings (dict):
             Integer key denoting priority (dict):
@@ -86,10 +87,12 @@ def safely_decode(binary_text, encodings, errors):
             text = binary_text.decode(detected)
             used = detected
             if len(valid) < 1:
-                desc = "No valid listed encodings, but successfully decoded with detected encoding " + detected
+                desc = "No valid listed encodings, but successfully decoded " + body_type + " body with detected encoding " + detected
             else:
                 desc = (
-                    "Failed to decode message body with listed encoding(s) "
+                    "Failed to decode "
+                    + body_type
+                    + " message body with listed encoding(s) "
                     + ", ".join(failed)
                     + " (lies!), but successfully decoded with detected encoding "
                     + detected
@@ -97,12 +100,12 @@ def safely_decode(binary_text, encodings, errors):
             errors = common.handle_error(errors, errorObj, desc, "warn")
         except UnicodeDecodeError as e:
             if len(valid) < 1:
-                desc = "No valid listed encodings. Failed to decode message body with detected encoding " + detected
+                desc = "No valid listed encodings. Failed to decode " + body_type + " message body with detected encoding " + detected
                 # just replace the errors
                 text = binary_text.decode(detected, errors="replace")
                 used = detected
             else:
-                desc = "Failed to decode message body with listed encoding(s) " + ", ".join(failed)
+                desc = "Failed to decode " + body_type + "message body with listed encoding(s) " + ", ".join(failed)
                 # just replace the errors
                 text = binary_text.decode(valid[0], errors="replace")
                 used = valid[0]


### PR DESCRIPTION
 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New component
- [x] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Previously, PST parsing relied on the listed encodings and failed to parse a message body if it didn't decode. EML/MBOX had implemented falling back to chardectect and finally replacing instead of failing. This implements this behavior for PST parsing too using a new `safely_decode()` helper method. EML/MBOX parsing has been refactored to use this helper as well.

## Link to issue?
N/A

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
