### PR TITLE
added manual utf-8 decode check for plain text pst bodies

### DIFF
--- a/mailbagit/formats/pst.py
+++ b/mailbagit/formats/pst.py
@@ -102,6 +102,10 @@ if not skip_registry:
                                 html_body, html_encoding, errors = format.safely_decode("HTML", messageObj.html_body, encodings, errors)
                             if messageObj.plain_text_body:
                                 encodings[len(encodings.keys()) + 1] = {
+                                    "name": "utf-8",
+                                    "label": "manual",
+                                }
+                                encodings[len(encodings.keys()) + 2] = {
                                     "name": chardet.detect(messageObj.plain_text_body)["encoding"],
                                     "label": "detected",
                                 }
@@ -273,4 +277,6 @@ if not skip_registry:
             if self.companion_files:
                 # Move all files into mailbag directory structure
                 for companion_file in companion_files:
-                    new_path = format.moveWithDirectoryStructure(self.dry_run, self.path, self.mailbag_name, self.format_name, companion_file)
+                    new_path = format.moveWithDirectoryStructure(
+                        self.dry_run, self.path, self.mailbag_name, self.format_name, companion_file
+                    )


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.
For parsing PST files, mailbagit now manually adds a `utf-8` decode check for plain text bodies, as this seems to work well. Like `.html_body`, it still tries `PidTagInternetCodepage` and `PidTagMessageCodepage`l as first priorities, but then tries `utf-8` and finally falls back to `chardetect`.

## Link to issue?

#176 

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
