### PR TITLE
external css now writes to <head><style> instead of a link

### DIFF
--- a/mailbagit/helper/derivative.py
+++ b/mailbagit/helper/derivative.py
@@ -185,18 +185,16 @@ def htmlFormatting(message, external_css, headers=True):
                 margin-bottom: 2px;
                 font-size: 24px;
                 font-family: Arial sans-serif;
+            }
         """
         style = soup.new_tag("style")
         style.string = default_css
-        soup.head.append(style)
-
         # Adding external_css
         if external_css:
-            link = soup.new_tag("link")
-            link["rel"] = "stylesheet"
-            link["type"] = "text/css"
-            link["href"] = "file:///" + external_css
-            soup.head.append(link)
+            with open(external_css) as css_file:
+                style.string = style.string + "\n" + css_file.read()
+                css_file.close()
+        soup.head.append(style)
 
         # Embedding Images
         # HT to extract_msg for this approach


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

External CSS at run now reads the CSS file at the path provided and writes the text into a `<style>` tag in the `<head>` for HTML, PDF, and PDF-Chrome derivatives. This was needed, as previously it used `<link ref=""`> to link to the CSS file locally, which is blocked by most browsers and the PDF conversion tools.

## Link to issue?

#140 

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
