### PR TITLE
fixed incompliant Content_Type header

### DIFF
--- a/mailbagit/controller.py
+++ b/mailbagit/controller.py
@@ -41,7 +41,7 @@ class Controller:
             "Cc",
             "Bcc",
             "Subject",
-            "Content_Type",
+            "Content-Type",
         ]
 
     @property

--- a/release.md
+++ b/release.md
@@ -15,7 +15,7 @@
 ## Building and pushing dev Docker image
 
 ```
-docker build -t ualbanyarchives/mailbagit:dev .
+docker build --no-cache -t ualbanyarchives/mailbagit:dev .
 docker push ualbanyarchives/mailbagit:dev
 ```
 
@@ -35,6 +35,6 @@ twine upload dist/*.gz dist/*.whl
 ## Building and pushing prod Docker image
 
 ```
-docker build -t ualbanyarchives/mailbagit:latest -f Dockerfile.production .
+docker build --no-cache -t ualbanyarchives/mailbagit:latest -f Dockerfile.production .
 docker push ualbanyarchives/mailbagit:latest
 ```


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Content-Type CSV header now incompliance with mailbagit spec. Also adds `--no-cashe` to docker build commands doc.

## Link to issue?

n/a

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** python 3.9.4

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
