### PR TITLE
htmlFormatter now doesn't break when attachment filenames are None

### DIFF
--- a/mailbagit/helper/derivative.py
+++ b/mailbagit/helper/derivative.py
@@ -173,7 +173,10 @@ def htmlFormatting(message, external_css, headers=True):
                 table += "<tr>"
                 table += "<td class='header'>Attachments</td><td>"
                 for i, attachment in enumerate(message.Attachments):
-                    table += attachment.Name
+                    if attachment.Name:
+                        table += attachment.Name
+                    else:
+                        table += str(i)
                     if i + 1 < attachmentNumber:
                         table += "<br/>"
                 table += "</td>"


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

htmlFormater helper was breaking since `Attachment.Name` can now be `None`. This fixes that.

## Link to issue?

n/a

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.9.4

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
