### PR TITLE
Split error reports

### DIFF
--- a/mailbagit/controller.py
+++ b/mailbagit/controller.py
@@ -52,7 +52,7 @@ class Controller:
     def derivative_map(self):
         return Derivative.registry
 
-    def message_to_csv(self, message):
+    def message_to_csv(self, message, csv_type="all"):
         """
         Builds a list used for CSV output lines for mailbag.csv and error reports
 
@@ -62,9 +62,12 @@ class Controller:
         Returns:
             list: line
         """
-        error_field = " ".join(message.Error).replace("\r\n", "\\r\\n").replace("\n", "\\n").strip()
+        error_field = []
+        for error in message.Errors:
+            if csv_type == "all" or csv_type == error.Level.lower():
+                error_field.append(error.Description)
         line = [
-            error_field,
+            " ".join(error_field),
             message.Mailbag_Message_ID,
             message.Message_ID,
             message.Original_File,
@@ -99,6 +102,7 @@ class Controller:
         mailbag_dir = os.path.join(parent_dir, self.args.mailbag_name)
         attachments_dir = os.path.join(str(mailbag_dir), "data", "attachments")
         error_dir = os.path.join(parent_dir, str(self.args.mailbag_name) + "_errors")
+        warn_dir = os.path.join(parent_dir, str(self.args.mailbag_name) + "_warnings")
 
         log.debug("Creating mailbag at " + str(mailbag_dir))
         if not self.args.dry_run:
@@ -141,6 +145,7 @@ class Controller:
         csv_portion_count = 0
         csv_portion = [self.csv_headers]
         error_csv = [self.csv_headers]
+        warn_csv = [self.csv_headers]
 
         # Count total no. of messages and set start time
         mail_account.iteration_only = True
@@ -176,16 +181,37 @@ class Controller:
             for d in derivatives:
                 message = d.do_task_per_message(message)
 
-            # creating text file and csv if error is present
-            if len(message.Error) > 0:
-                if not os.path.isdir(error_dir):
-                    # making error directory if error is present
-                    os.mkdir(error_dir)
-                error_csv.append(self.message_to_csv(message))
-                trace_file = os.path.join(error_dir, str(message.Mailbag_Message_ID) + ".txt")
-                with open(trace_file, "w", encoding="utf-8") as f:
-                    f.write("\n".join(str(error) for error in message.StackTrace))
-                    f.close()
+            # Error and Warning Reports
+            if len(message.Errors) > 0:
+                error_stack_trace = []
+                warn_stack_trace = []
+                for error in message.Errors:
+                    if error.Level.lower() == "warn":
+                        warn_stack_trace.append(error.StackTrace)
+                    else:
+                        error_stack_trace.append(error.StackTrace)
+
+                # Write Error Report
+                if len(error_stack_trace) > 0:
+                    if not os.path.isdir(error_dir):
+                        # making error directory if error is present
+                        os.mkdir(error_dir)
+                    error_csv.append(self.message_to_csv(message, "error"))
+                    error_trace_file = os.path.join(error_dir, str(message.Mailbag_Message_ID) + ".txt")
+                    with open(error_trace_file, "w", encoding="utf-8") as f:
+                        f.write("\n".join(error_stack_trace))
+                        f.close()
+
+                # Write Warning Report
+                if len(warn_stack_trace) > 0:
+                    if not os.path.isdir(warn_dir):
+                        # making error directory if error is present
+                        os.mkdir(warn_dir)
+                    warn_csv.append(self.message_to_csv(message, "warn"))
+                    warn_trace_file = os.path.join(warn_dir, str(message.Mailbag_Message_ID) + ".txt")
+                    with open(warn_trace_file, "w", encoding="utf-8") as f:
+                        f.write("\n".join(warn_stack_trace))
+                        f.close()
 
             # Show progress
             # If progress%(total_messages/100)==0 then show progress
@@ -234,6 +260,12 @@ class Controller:
             with open(filename, "w", encoding="utf-8", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerows(error_csv)
+        log.debug("Writing warnings.csv to " + str(warn_dir))
+        if len(warn_csv) > 1:
+            filename = os.path.join(warn_dir, "warnings.csv")
+            with open(filename, "w", encoding="utf-8", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerows(warn_csv)
 
         if not self.args.dry_run:
             bag_size = 0

--- a/mailbagit/derivatives/eml.py
+++ b/mailbagit/derivatives/eml.py
@@ -39,10 +39,7 @@ class EmlDerivative(Derivative):
 
     def do_task_per_message(self, message):
 
-        errors = {}
-        errors["msg"] = []
-        errors["stack_trace"] = []
-
+        errors = []
         try:
 
             out_dir = os.path.join(self.eml_dir, message.Derivatives_Path)
@@ -174,7 +171,6 @@ class EmlDerivative(Derivative):
             desc = "Error creating EML derivative"
             errors = common.handle_error(errors, e, desc)
 
-        message.Error.extend(errors["msg"])
-        message.StackTrace.extend(errors["stack_trace"])
+        message.Errors.extend(errors)
 
         return message

--- a/mailbagit/derivatives/html.py
+++ b/mailbagit/derivatives/html.py
@@ -30,10 +30,7 @@ class HtmlDerivative(Derivative):
 
     def do_task_per_message(self, message):
 
-        errors = {}
-        errors["msg"] = []
-        errors["stack_trace"] = []
-
+        errors = []
         try:
 
             if message.Derivatives_Path is None:
@@ -71,7 +68,6 @@ class HtmlDerivative(Derivative):
             desc = "Error creating HTML derivative"
             errors = common.handle_error(errors, e, desc)
 
-        message.Error.extend(errors["msg"])
-        message.StackTrace.extend(errors["stack_trace"])
+        message.Errors.extend(errors)
 
         return message

--- a/mailbagit/derivatives/mbox.py
+++ b/mailbagit/derivatives/mbox.py
@@ -35,10 +35,7 @@ class MboxDerivative(Derivative):
 
     def do_task_per_message(self, message):
 
-        errors = {}
-        errors["msg"] = []
-        errors["stack_trace"] = []
-
+        errors = []
         try:
 
             try:
@@ -166,7 +163,6 @@ class MboxDerivative(Derivative):
             desc = "Error creating MBOX derivative"
             errors = common.handle_error(errors, e, desc)
 
-        message.Error.extend(errors["msg"])
-        message.StackTrace.extend(errors["stack_trace"])
+        message.Errors.extend(errors)
 
         return message

--- a/mailbagit/derivatives/pdf.py
+++ b/mailbagit/derivatives/pdf.py
@@ -50,9 +50,7 @@ if not skip_registry:
 
         def do_task_per_message(self, message):
 
-            errors = {}
-            errors["msg"] = []
-            errors["stack_trace"] = []
+            errors = []
 
             try:
 
@@ -115,7 +113,6 @@ if not skip_registry:
                 desc = "Error creating PDF derivative"
                 errors = common.handle_error(errors, e, desc)
 
-            message.Error.extend(errors["msg"])
-            message.StackTrace.extend(errors["stack_trace"])
+            message.Errors.extend(errors)
 
             return message

--- a/mailbagit/derivatives/pdf_chrome.py
+++ b/mailbagit/derivatives/pdf_chrome.py
@@ -42,10 +42,7 @@ if not skip_registry:
 
         def do_task_per_message(self, message):
 
-            errors = {}
-            errors["msg"] = []
-            errors["stack_trace"] = []
-
+            errors = []
             try:
 
                 out_dir = os.path.join(self.pdf_dir, message.Derivatives_Path)
@@ -110,7 +107,6 @@ if not skip_registry:
                 desc = "Error creating PDF derivative with chrome"
                 errors = common.handle_error(errors, e, desc)
 
-            message.Error.extend(errors["msg"])
-            message.StackTrace.extend(errors["stack_trace"])
+            message.Errors.extend(errors)
 
             return message

--- a/mailbagit/derivatives/txt.py
+++ b/mailbagit/derivatives/txt.py
@@ -29,10 +29,7 @@ class TxtDerivative(Derivative):
 
     def do_task_per_message(self, message):
 
-        errors = {}
-        errors["msg"] = []
-        errors["stack_trace"] = []
-
+        errors = []
         try:
 
             out_dir = os.path.join(self.txt_dir, message.Derivatives_Path)
@@ -59,7 +56,6 @@ class TxtDerivative(Derivative):
             desc = "Error creating plain text derivative"
             errors = common.handle_error(errors, e, desc)
 
-        message.Error.extend(errors["msg"])
-        message.StackTrace.extend(errors["stack_trace"])
+        message.Errors.extend(errors)
 
         return message

--- a/mailbagit/derivatives/warc.py
+++ b/mailbagit/derivatives/warc.py
@@ -65,9 +65,7 @@ class WarcDerivative(Derivative):
 
     def do_task_per_message(self, message):
 
-        errors = {}
-        errors["msg"] = []
-        errors["stack_trace"] = []
+        errors = []
 
         try:
 
@@ -136,7 +134,6 @@ class WarcDerivative(Derivative):
             desc = "Error creating WARC derivative"
             errors = common.handle_error(errors, e, desc)
 
-        message.Error.extend(errors["msg"])
-        message.StackTrace.extend(errors["stack_trace"])
+        message.Errors.extend(errors)
 
         return message

--- a/mailbagit/formats/eml.py
+++ b/mailbagit/formats/eml.py
@@ -60,9 +60,7 @@ class EML(EmailAccount):
             originalFile = Path(format.relativePath(self.path, filePath)).as_posix()
 
             attachments = []
-            errors = {}
-            errors["msg"] = []
-            errors["stack_trace"] = []
+            errors = []
             try:
                 with open(filePath, "rb") as f:
                     msg = email.message_from_binary_file(f, policy=email.policy.default)
@@ -96,7 +94,7 @@ class EML(EmailAccount):
                         errors = common.handle_error(errors, e, desc)
 
                     message = Email(
-                        Error=errors["msg"],
+                        Errors=errors,
                         Message_ID=format.parse_header(msg["message-id"]),
                         Original_File=originalFile,
                         Message_Path=messagePath,
@@ -113,13 +111,12 @@ class EML(EmailAccount):
                         Text_Encoding=bodies["text_encoding"],
                         Message=msg,
                         Attachments=attachments,
-                        StackTrace=errors["stack_trace"],
                     )
 
             except (email.errors.MessageParseError, Exception) as e:
                 desc = "Error parsing message"
                 errors = common.handle_error(errors, e, desc)
-                message = Email(Error=errors["msg"], StackTrace=errors["stack_trace"])
+                message = Email(Errors=errors)
 
             # Move EML to new mailbag directory structure
             yield message

--- a/mailbagit/formats/mbox.py
+++ b/mailbagit/formats/mbox.py
@@ -73,9 +73,7 @@ class Mbox(EmailAccount):
                     continue
 
                 attachments = []
-                errors = {}
-                errors["msg"] = []
-                errors["stack_trace"] = []
+                errors = []
 
                 try:
                     mailObject = email.message_from_bytes(mail.as_bytes(), policy=email.policy.default)
@@ -107,7 +105,7 @@ class Mbox(EmailAccount):
                         errors = common.handle_error(errors, e, desc)
 
                     message = Email(
-                        Error=errors["msg"],
+                        Errors=errors,
                         Message_ID=format.parse_header(mail["Message-ID"]),
                         Original_File=originalFile,
                         Message_Path=messagePath,
@@ -126,12 +124,11 @@ class Mbox(EmailAccount):
                         Text_Encoding=bodies["text_encoding"],
                         Message=mailObject,
                         Attachments=attachments,
-                        StackTrace=errors["stack_trace"],
                     )
                 except (email.errors.MessageParseError, Exception) as e:
                     desc = "Error parsing message"
                     errors = common.handle_error(errors, e, desc)
-                    message = Email(Error=errors["msg"], StackTrace=errors["stack_trace"])
+                    message = Email(Errors=errors)
 
                 yield message
 

--- a/mailbagit/formats/msg.py
+++ b/mailbagit/formats/msg.py
@@ -61,12 +61,9 @@ class MSG(EmailAccount):
             originalFile = Path(format.relativePath(self.path, filePath)).as_posix()
 
             attachments = []
-            errors = {}
-            errors["msg"] = []
-            errors["stack_trace"] = []
+            errors = []
             try:
                 mail = extract_msg.openMsg(filePath)
-
                 # Parse message bodies
                 html_body = None
                 text_body = None
@@ -95,6 +92,7 @@ class MSG(EmailAccount):
                     errors = common.handle_error(errors, e, desc)
 
                 try:
+                    blah
                     for mailAttachment in mail.attachments:
                         if mailAttachment.getFilename():
                             attachmentName = mailAttachment.getFilename()
@@ -126,7 +124,6 @@ class MSG(EmailAccount):
 
                         # MSGs don't seem to have a reliable content ID so we make one since emails may have multiple attachments with the same filename
                         contentID = uuid.uuid4().hex
-
                         attachment = Attachment(
                             Name=attachmentName,
                             File=mailAttachment.data,
@@ -140,7 +137,7 @@ class MSG(EmailAccount):
                     errors = common.handle_error(errors, e, desc)
 
                 message = Email(
-                    Error=errors["msg"],
+                    Errors=errors,
                     Message_ID=mail.messageId.strip(),
                     Original_File=originalFile,
                     Message_Path=messagePath,
@@ -161,7 +158,6 @@ class MSG(EmailAccount):
                     # Doesn't look like we can feasibly get a full email.message.Message object for .msg
                     Message=None,
                     Attachments=attachments,
-                    StackTrace=errors["stack_trace"],
                 )
                 # Make sure the MSG file is closed
                 mail.close()
@@ -169,7 +165,7 @@ class MSG(EmailAccount):
             except (email.errors.MessageParseError, Exception) as e:
                 desc = "Error parsing message"
                 errors = common.handle_error(errors, e, desc)
-                message = Email(Error=errors["msg"], StackTrace=errors["stack_trace"])
+                message = Email(Errors=errors)
                 # Make sure the MSG file is closed
                 mail.close()
 

--- a/mailbagit/formats/msg.py
+++ b/mailbagit/formats/msg.py
@@ -92,7 +92,6 @@ class MSG(EmailAccount):
                     errors = common.handle_error(errors, e, desc)
 
                 try:
-                    blah
                     for mailAttachment in mail.attachments:
                         if mailAttachment.getFilename():
                             attachmentName = mailAttachment.getFilename()

--- a/mailbagit/formats/pst.py
+++ b/mailbagit/formats/pst.py
@@ -59,9 +59,7 @@ if not skip_registry:
                         yield None
                         continue
                     attachments = []
-                    errors = {}
-                    errors["msg"] = []
-                    errors["stack_trace"] = []
+                    errors = []
                     try:
                         messageObj = folder.get_sub_message(index)
 
@@ -201,7 +199,7 @@ if not skip_registry:
                             errors = common.handle_error(errors, e, desc)
 
                         message = Email(
-                            Error=errors["msg"],
+                            Errors=errors,
                             Message_ID=format.parse_header(headers["Message-ID"]),
                             Original_File=originalFile,
                             Message_Path=messagePath,
@@ -220,13 +218,12 @@ if not skip_registry:
                             Text_Encoding=text_encoding,
                             Message=None,
                             Attachments=attachments,
-                            StackTrace=errors["stack_trace"],
                         )
 
                     except (Exception) as e:
                         desc = "Error parsing message"
                         errors = common.handle_error(errors, e, desc)
-                        message = Email(Error=errors["msg"], StackTrace=errors["stack_trace"])
+                        message = Email(Errors=errors)
 
                     yield message
 

--- a/mailbagit/helper/common.py
+++ b/mailbagit/helper/common.py
@@ -1,5 +1,5 @@
 import traceback
-
+from mailbagit.models import Error
 from structlog import get_logger
 
 log = get_logger()
@@ -7,39 +7,44 @@ log = get_logger()
 
 def handle_error(errors, exception, desc, level="error"):
     """
-    Is called when an exception is raised in the parsers.
-    returns a dict of readable and full trace errors that can be appended to.
+    Is called when an exception is raised in the parsers, helpers, or derivatives.
+    Takes a list, creates an Error object, and returns the list with the Error object appended.
+    Messages can have multiple error objects, so this may be called multiple times per message
 
     Parameters:
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
         exception (Exception): The exception raised
         desc (String): A full email message object desribed in models.py
         level (String): Whether to log as error or warn. Defaults to error.
     Returns:
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
     """
     if exception:
-        error_msg = level.upper() + ": " + desc + ": " + repr(exception)
+        error_msg = desc + ": " + repr(exception)
         stack_header = (
             "**************************************************************************\n"
+            + level.upper()
+            + ": "
             + error_msg
             + "\n**************************************************************************\n"
         )
-        errors["stack_trace"].append(stack_header + traceback.format_exc())
+        stack_trace = stack_header + traceback.format_exc()
     else:
-        error_msg = level.upper() + ": " + desc + "."
-        errors["stack_trace"].append(desc + ".")
-    errors["msg"].append(error_msg)
+        error_msg = desc + "."
+        stack_trace = level.upper() + ": " + desc + "."
 
-    print()
+    # print()
     log_msg = (error_msg[:150] + "..") if len(error_msg) > 150 else error_msg
     if level == "warn":
         log.warn(log_msg)
     else:
         log.error(log_msg)
+
+    errorObj = Error(
+        Level=level,
+        Description=level.upper() + ": " + error_msg,
+        StackTrace=stack_trace,
+    )
+    errors.append(errorObj)
 
     return errors

--- a/mailbagit/helper/controller.py
+++ b/mailbagit/helper/controller.py
@@ -3,6 +3,7 @@ import datetime
 from time import time
 import csv
 
+import mailbagit.helper.common as common
 import mailbagit.globals as globals
 
 from structlog import get_logger

--- a/mailbagit/helper/format.py
+++ b/mailbagit/helper/format.py
@@ -50,16 +50,12 @@ def safely_decode(body_type, binary_text, encodings, errors):
             Integer key denoting priority (dict):
                 "name" (str):
                 "label" (str): a description for the encoding, such as its source
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
 
     Returns:
         test (str): a decoded unicode string
         used (str): The encoding used to decode the text
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
     """
     errorObj = None
     used = None
@@ -128,17 +124,13 @@ def parse_part(part, bodies, attachments, errors):
             "msg" contains a list of human readable error messages
             "stack_trace" contains a list of full stack traces
         attachments (list): a list of attachment object as defined in models.py
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
     Returns:
         bodies (dict):
             "msg" contains a list of human readable error messages
             "stack_trace" contains a list of full stack traces
         attachments (list): a list of attachment object as defined in models.py
-        errors (dict):
-            "msg" contains a list of human readable error messages
-            "stack_trace" contains a list of full stack traces
+        errors (List): List of Error objects defined in models.py
     """
     content_type = part.get_content_type()
     content_disposition = part.get_content_disposition()

--- a/mailbagit/models.py
+++ b/mailbagit/models.py
@@ -10,10 +10,16 @@ class Attachment(models.Base):
     Content_ID = fields.StringField()
 
 
+class Error(models.Base):
+    Level = fields.StringField()
+    Description = fields.StringField()
+    StackTrace = fields.StringField()
+
+
 class Email(models.Base):
     """EmailModel - model class for email formats"""
 
-    Error = fields.ListField(str)
+    Errors = fields.ListField(Error)
     Mailbag_Message_ID = fields.IntField()
     Message_ID = fields.StringField()
     Original_File = fields.StringField()
@@ -33,7 +39,6 @@ class Email(models.Base):
     Text_Encoding = fields.StringField()
     Message = fields.EmbeddedField(Message)
     Attachments = fields.ListField(Attachment)
-    StackTrace = fields.ListField(str)
 
     def dump_string(self, value, outpath, encoding=None):
         with open(outpath + ".txt", "w", encoding="utf-8", newline="\n") as f:


### PR DESCRIPTION
 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Previously, the format parsers all used an `errors` dict with keys `msg` for a human-readable error message and `stack_trace` for full stack traces both of which were lists. A number of try/excepts used the `common.handle_error()` helper to append to the lists. The format parsers then returned `message.Error` and `message.StackTrace` fields to the model. The derivatives modules also caught errors using a similar `errors` dict and added these to the model too. Finally, the controller used this data to write an error report.

The `errors` dict was a bit weird, so now there is an `message.Errors` field which is a list of `Error` objects which are newly defined in `models.py` The `common.handle_error` helper now creates these new `Error` objects and appends them to the `message.Errors` field. This works for both the format parsers and the derivatives. The `Error` objects also have a new `Error.Level` field that denotes if the error is `error` or `warn`. The controller now uses this to create two separate error reports, for errors and warnings. This should help users better distinguish between the two.

## Link to issue?

#194 

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
