### PR TITLE
now allows for custom external identifier to be set with an arg

### DIFF
--- a/mailbagit/controller.py
+++ b/mailbagit/controller.py
@@ -113,9 +113,11 @@ class Controller:
             bag.info["Mailbag-Specification-Version"] = "0.3"
             bag.info["Mailbag-Source"] = self.args.input.lower()
             bag.info["Original-Included"] = "True"
-            bag.info["External-Identifier"] = uuid.uuid4()
             bag.info["Mailbag-Agent"] = mailbagit.__name__
             bag.info["Mailbag-Agent-Version"] = mailbagit.__version__
+            # Make sure now custom external-idenifier is in args
+            if not "external-identifier" in set(key.lower() for key in self.args.bag_info.keys()):
+                bag.info["External-Identifier"] = uuid.uuid4()
             # user-supplied mailbag metadata
             user_metadata = ["Capture-Date", "Capture-Agent", "Capture-Agent-Version"]
             for user_field in user_metadata:


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Allows you to set a custom identifier using `--external-identifier` just like bagit-python.

## Link to issue?

#203 

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
