### PR TITLE
use new extractMsg attributes

### DIFF
--- a/mailbagit/formats/msg.py
+++ b/mailbagit/formats/msg.py
@@ -114,15 +114,22 @@ class MSG(EmailAccount):
                         # Try to get the mime, guess it if this doesn't work
                         mime = None
                         try:
-                            mime = mailAttachment._ensureSet("_contentType", "__substg1.0_370e")
+                            mime = mailAttachment.mimetype
                         except Exception as e:
                             desc = "Error reading mime type, guessing it instead"
                             errors = common.handle_error(errors, e, desc, "warn")
                         if mime is None:
                             mime = format.guessMimeType(attachmentName)
 
-                        # MSGs don't seem to have a reliable content ID so we make one since emails may have multiple attachments with the same filename
-                        contentID = uuid.uuid4().hex
+                        contentID = None
+                        try:
+                            contentID = mailAttachment.contendId
+                        except Exception as e:
+                            desc = "Error reading ContentID, creating an ID instead"
+                            errors = common.handle_error(errors, e, desc, "warn")
+                        if contentID is None:
+                            contentID = uuid.uuid4().hex
+
                         attachment = Attachment(
                             Name=attachmentName,
                             File=mailAttachment.data,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "beautifulsoup4>=4.11.1,<5",
         "black>=22.1.0,<23",
         "jsonmodels>=2.2,<=2.5.0",
-        "extract_msg>=0.30.10,<1",
+        "extract_msg>=0.34.1,<1",
         "structlog>=21.1.0,<22",
         "pyparsing>=2.1.0,<3",
         "pytest>=7.0.1,<8",


### PR DESCRIPTION
 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [x] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Implements the new `mime` and `contentId` attributes in v0.31.0+ versions of extractMsg per [#256](https://github.com/TeamMsgExtractor/msg-extractor/issues/256)

## Link to issue?

 [#256](https://github.com/TeamMsgExtractor/msg-extractor/issues/256)

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
