### PR TITLE
eml and msg imputs now accept individual files as well as directories

### DIFF
--- a/mailbagit/formats/msg.py
+++ b/mailbagit/formats/msg.py
@@ -38,18 +38,24 @@ class MSG(EmailAccount):
         return account_data
 
     def messages(self):
-        fileList = []
+
         companion_files = []
-        for root, dirs, files in os.walk(self.path):
-            for file in files:
-                mailbag_path = os.path.join(self.path, self.mailbag_name) + os.sep
-                fileRoot = root + os.sep
-                # don't count the newly-created mailbag
-                if not fileRoot.startswith(mailbag_path):
-                    if file.lower().endswith("." + self.format_name):
-                        fileList.append(os.path.join(root, file))
-                    elif self.companion_files:
-                        companion_files.append(os.path.join(root, file))
+        if os.path.isfile(self.path):
+            parent_dir = os.path.dirname(self.path)
+            fileList = [self.path]
+        else:
+            parent_dir = self.path
+            fileList = []
+            for root, dirs, files in os.walk(self.path):
+                for file in files:
+                    mailbag_path = os.path.join(self.path, self.mailbag_name) + os.sep
+                    fileRoot = root + os.sep
+                    # don't count the newly-created mailbag
+                    if not fileRoot.startswith(mailbag_path):
+                        if file.lower().endswith("." + self.format_name):
+                            fileList.append(os.path.join(root, file))
+                        elif self.companion_files:
+                            companion_files.append(os.path.join(root, file))
 
         for filePath in fileList:
             # Parse email matching the input file extension
@@ -58,7 +64,14 @@ class MSG(EmailAccount):
                 yield None
                 continue
 
-            originalFile = Path(format.relativePath(self.path, filePath)).as_posix()
+            rel_path = format.relativePath(self.path, filePath)
+            if len(rel_path) < 1:
+                originalFile = Path(filePath).name
+            else:
+                originalFile = Path(os.path.normpath(rel_path)).as_posix()
+            # original file is now the relative path to the MBOX from the provided path
+
+            # originalFile = Path(format.relativePath(self.path, filePath)).as_posix()
 
             attachments = []
             errors = []
@@ -169,7 +182,7 @@ class MSG(EmailAccount):
                 mail.close()
 
             # Move MSG to new mailbag directory structure
-            new_path = format.moveWithDirectoryStructure(self.dry_run, self.path, self.mailbag_name, self.format_name, filePath)
+            new_path = format.moveWithDirectoryStructure(self.dry_run, parent_dir, self.mailbag_name, self.format_name, filePath)
             yield message
 
         if self.companion_files:


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Previously EML and MSG source files could only be provided within a directly. Now users can package individual MSG or EML files as stated in the documentation.

## Link to issue?

n/a

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
