### PR TITLE
PDF derivative conflict

### DIFF
--- a/mailbagit/__init__.py
+++ b/mailbagit/__init__.py
@@ -263,22 +263,14 @@ def main(args):
         error_msg = "Invalid path, does not exist as a file or directory."
         mailbag_parser.error((error_msg))
 
-    """
-    # handle arg errors
-    if args.input not in EmailAccount.registry.keys():
-        error_msg = 'Invalid derivatives, choose from: "' + '", "'.join(EmailAccount.registry.keys()) + '"'
-        mailbag_parser.error((error_msg))
-
-    if isinstance(args.derivatives, str):
-        args.derivatives = args.derivatives.split(" ")
-        if not all(elem in derivative_types for elem in args.derivatives):
-            error_msg = 'Invalid derivatives, choose from: "' + '", "'.join(derivative_types) + '"'
-            mailbag_parser.error((error_msg))
-
     if args.input in args.derivatives:
         error_msg = "Invalid derivatives, mailbagit does not support the source format as a derivative."
         mailbag_parser.error((error_msg))
-    """
+
+    # Check for multiple pdf derivatives, liek both pdf and pdf-chrome
+    if ["pdf" in x for x in args.derivatives].count(True) > 1:
+        error_msg = "Invalid derivatives, mailbagit can only use one module to make PDF derivatives"
+        mailbag_parser.error((error_msg))
 
     if args.processes < 1:
         error_msg = "processes must be valid integer > 0"

--- a/mailbagit/__init__.py
+++ b/mailbagit/__init__.py
@@ -267,7 +267,7 @@ def main(args):
         error_msg = "Invalid derivatives, mailbagit does not support the source format as a derivative."
         mailbag_parser.error((error_msg))
 
-    # Check for multiple pdf derivatives, liek both pdf and pdf-chrome
+    # Check for multiple pdf derivatives, like both pdf and pdf-chrome
     if ["pdf" in x for x in args.derivatives].count(True) > 1:
         error_msg = "Invalid derivatives, mailbagit can only use one module to make PDF derivatives"
         mailbag_parser.error((error_msg))


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Now raises an error if a user tries to use both `pdf` and `pdf-chrome` derivatives to prevent conflicts. Also reinstates validation for both same input and derivatives and cleans up old validations.

## Link to issue?

#209

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.9.12

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
