### PR TITLE
Python 3.10.7 fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install libgtk-3-dev
       - name: Install Python dependencies
         run: |
-          pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 wxPython
+          pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
           pip install .
           pip install libpff-python==20211114
       - name: Test with pytest

--- a/mailbagit/__init__.py
+++ b/mailbagit/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py
 
 # Version of the mailbagit package
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 import os
 from pathlib import Path
@@ -260,7 +260,10 @@ if gooeyCheck:
 
 
 def main(args):
-    setup_logging(stream_json=args.log_json, filename=args.log)
+    if hasattr(args, 'log_json'):
+        setup_logging(stream_json=args.log_json, filename=args.log)
+    else:
+        setup_logging(filename=args.log)
     args.input = args.input.lower()
 
     if not os.path.exists(args.path[0]):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="mailbagit",
-    version="0.4.1",
+    version="0.4.2",
     author="Gregory Wiedeman",
     author_email="gwiedeman@albany.edu",
     description="A tool for preserving email with multiple masters.",


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

python 3.10.7 seems to be stricter with making sure all argparse args are present before calling the attribute. Previously, 3.9.x worked, but 3.10.7 returned
```
Traceback (most recent call last):
  File "C:\Users\Greg\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Greg\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Greg\.virtualenvs\mailbagit-VBypqmo4\Scripts\mailbagit.exe\__main__.py", line 7, in <module>
  File "C:\Projects\mailbagit\mailbagit\__init__.py", line 242, in cli
  File "C:\Projects\mailbagit\mailbagit\__init__.py", line 264, in main
    setup_logging(stream_json=args.log_json, filename=args.log)
AttributeError: 'Namespace' object has no attribute 'log_json'
```

## Link to issue?

n/a

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.10.7

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
