### PR TITLE
now detects mbox files without extentions from Mac Mail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV TZ=America/New_York \
     MAILBAGIT_LOG_LEVEL=debug\
     IN_CONTAINER=true
 
-RUN mkdir /mailbagit
-WORKDIR /mailbagit
-ADD . /mailbagit/
+#RUN mkdir /mailbagit
+#WORKDIR /mailbagit
+#ADD . /mailbagit/
 
 # manually add to $PYTHONPATH because https://github.com/python/importlib_metadata/issues/364
 ENV PYTHONPATH=/mailbagit
@@ -32,5 +32,3 @@ RUN apt-get install -y /tmp/google-chrome-stable_current_amd64.deb
 RUN curl -L -o /tmp/wkhtmltox_0.12.6-1.buster_amd64.deb \ 
         https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb
 RUN dpkg -i /tmp/wkhtmltox_0.12.6-1.buster_amd64.deb
-
-RUN pip install -e .[pst]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+version: '3.1'
+
+services:
+  mailbagit:
+    image: ualbanyarchives/mailbagit:dev
+    volumes:
+      - '../sampleData:/data'
+      - '.:/mailbagit'
+    tty: true
+    stdin_open: true
+    restart: always
+    working_dir: /mailbagit
+    entrypoint: /bin/bash

--- a/docs/installing_mailbagit/docker.md
+++ b/docs/installing_mailbagit/docker.md
@@ -35,7 +35,7 @@ docker compose run mailbag
 
 ## Run with bind mount.
 
-You can also use a bind mount to give the container and `mailbagit` access to the files you want to process.
+You can also use a bind mount to give the container and `mailbagit` access to another directory.
 
 Mailbagit will have access to the directory listed in the `source=` argument, which will be accessible in the container using the `/data` path.
 
@@ -79,11 +79,12 @@ Remember to stop the container when you're done!
 
 ## Development Docker image
 
-There is also a development image available:
+There is also a development image available. This contains an consistent environment for mailbagit, but allows you to work directly with local code. Mounts a directory with test email data at `../sampleData` to `/data`.
 
 ```
 docker pull ualbanyarchives/mailbagit:dev
-docker run -it ualbanyarchives/mailbagit:dev
+docker compose -f docker-compose-dev.yml run mailbagit
+pip install -e .[pst]
 ```
 
 ### Other helpful docker commands

--- a/mailbagit/__init__.py
+++ b/mailbagit/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py
 
 # Version of the mailbagit package
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 import os
 from pathlib import Path

--- a/mailbagit/formats/mbox.py
+++ b/mailbagit/formats/mbox.py
@@ -59,7 +59,8 @@ class Mbox(EmailAccount):
                     fileRoot = root + os.sep
                     # don't count the newly-created mailbag
                     if not fileRoot.startswith(mailbag_path):
-                        if file.lower().endswith("." + self.format_name):
+                        # Mac Mail export file is "mbox" without an extension, so this checks that
+                        if file.lower().endswith("." + self.format_name) or file.lower().strip() == "mbox":
                             fileList.append(os.path.join(root, file))
                         elif self.companion_files:
                             companion_files.append(os.path.join(root, file))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="mailbagit",
-    version="0.5.0",
+    version="0.5.1",
     author="Gregory Wiedeman",
     author_email="gwiedeman@albany.edu",
     description="A tool for preserving email with multiple masters.",


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [x] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Mailbagit MBOX input now correctly detects mbox files without extensions from Mac Mail, addressing #232. It does this by assuming a file literally named `mbox` without a file extension is an mbox file. If it cannot parse `mbox` as an MBOX file, it will raise an error.

Also contains a better development setup for docker.

## Link to issue?

#232

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** python:3.11.2-slim-buster, Win10
**Python Version:** 3.9.16 and 3.11.2

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
