### PR TITLE
pinned to version of extract_msg

### DIFF
--- a/data/msg-Digitization Archiving Solutions/1/HTML_Body.txt
+++ b/data/msg-Digitization Archiving Solutions/1/HTML_Body.txt
@@ -334,7 +334,7 @@ adds maximum image quality, enhanced productivity, and increased efficiency that
 </p>
 <p class="MsoListParagraph" style="margin-left:1.0in;text-indent:-.5in;mso-list:l0 level1 lfo3"> 
 <![if !supportLists]>
-<span style="mso-list:Ignore">•
+<span style="mso-list:Ignore"> •
 <span style="font:7.0pt &quot;Times New Roman&quot;"> 
 &nbsp; 
 &nbsp; 
@@ -366,7 +366,7 @@ adds maximum image quality, enhanced productivity, and increased efficiency that
 </p>
 <p class="MsoListParagraph" style="margin-left:1.0in;text-indent:-.5in;mso-list:l0 level1 lfo3"> 
 <![if !supportLists]>
-<span style="mso-list:Ignore">•
+<span style="mso-list:Ignore"> •
 <span style="font:7.0pt &quot;Times New Roman&quot;"> 
 &nbsp; 
 &nbsp; 
@@ -398,7 +398,7 @@ adds maximum image quality, enhanced productivity, and increased efficiency that
 </p>
 <p class="MsoListParagraph" style="margin-left:1.0in;text-indent:-.5in;mso-list:l0 level1 lfo3"> 
 <![if !supportLists]>
-<span style="mso-list:Ignore">•
+<span style="mso-list:Ignore"> •
 <span style="font:7.0pt &quot;Times New Roman&quot;"> 
 &nbsp; 
 &nbsp; 
@@ -430,7 +430,7 @@ adds maximum image quality, enhanced productivity, and increased efficiency that
 </p>
 <p class="MsoListParagraph" style="margin-left:1.0in;text-indent:-.5in;mso-list:l0 level1 lfo3"> 
 <![if !supportLists]>
-<span style="mso-list:Ignore">•
+<span style="mso-list:Ignore"> •
 <span style="font:7.0pt &quot;Times New Roman&quot;"> 
 &nbsp; 
 &nbsp; 

--- a/mailbagit/__init__.py
+++ b/mailbagit/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py
 
 # Version of the mailbagit package
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 import os
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="mailbagit",
-    version="0.6.1",
+    version="0.6.2",
     author="Gregory Wiedeman",
     author_email="gwiedeman@albany.edu",
     description="A tool for preserving email with multiple masters.",
@@ -25,7 +25,7 @@ setuptools.setup(
         "beautifulsoup4>=4.11.1,<5",
         "black>=22.1.0,<23",
         "jsonmodels>=2.2,<=2.5.0",
-        "extract_msg>=0.34.3,<1",
+        "extract_msg>=0.34.3,<0.42.0",
         "structlog>=21.1.0,<22",
         "packaging>=21.0,<21.3",
         "python-json-logger>=2.0.2,<3",


### PR DESCRIPTION
 ## Type of Contribution

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Pins to < 0.42.0 version of extract_msg to avoid import error. I could fix it but for now its better to pin to a version that I know works.

## Link to issue?

#237 237

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.9.16

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbagit/blob/main/LICENSE).
